### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ It is written "栞" in Kanji, this caracter is 0x681E in Unicode.
    :target: http://travis-ci.org/mkouhei/shiori
 .. image:: https://coveralls.io/repos/mkouhei/shiori/badge.png?branch=devel
    :target: https://coveralls.io/r/mkouhei/shiori?branch=devel
-.. image:: https://pypip.in/v/shiori/badge.png
+.. image:: https://img.shields.io/pypi/v/shiori.svg
    :target: https://crate.io/packages/shiori
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20shiori))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `shiori`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.